### PR TITLE
Implement Clojurescript port for self-hosted Clojurescript.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cpcache
 .clj-kondo/.cache
 *.jar
+cljs-test-runner-out

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ and command-line tools.
 Works with Clojure 1.8 and later. Spec expectations are only available on
 Clojure 1.9 and later.
 
+Works in self-hosted Clojurescript (specifically,
+[`planck`](https://planck-repl.org)).  See
+[Getting Started with Clojurescript](/doc/getting-started-cljs.md) for details.
+
 You can either use `deftest` from `clojure.test`, or `defexpect` from
 this library to wrap your tests.
 
@@ -243,6 +247,46 @@ do
   clojure -A:test:runner:$v:humane -e :negative
 done
 ```
+
+### Clojurescript testing
+
+The Clojurescript version requires self-hosted Clojurescript (specifically,
+[`planck`](https://planck-repl.org)).  Once you have `planck -h` working,
+you can run the Clojurescript tests with:
+
+```clojure
+clojure -A:cljs-runner -e :negative
+```
+You can run the negative tests as well if you modify one line of `test.cljc`,
+see the comments below the line containing `(def humane-test-output?`.
+
+#### Clojurescript REPL
+
+It can be handy to try things in a REPL.  You can run a REPL for Clojurescript
+by doing:
+```clojure
+$ planck --compile-opts planckopts.edn -c `clj -A:humane -Spath` -r
+ClojureScript 1.10.520
+cljs.user=> (require '[expectations.clojure.test :refer-macros [defexpect expect]])
+nil
+cljs.user=> (defexpect a (expect number? 1))
+#'cljs.user/a
+cljs.user=> (a)
+nil
+cljs.user=> (defexpect a (expect number? :b))
+#'cljs.user/a
+cljs.user=> (a)
+
+FAIL in (a) (run_block@file:44:173)
+
+
+expected: (=? number? :b)
+  actual: (not (number? :b))
+nil
+cljs.user=>
+```
+This will set you up with `defexpect` and `expect`.  Add others as required.
+
 
 ## License & Copyright
 

--- a/deps.edn
+++ b/deps.edn
@@ -10,4 +10,11 @@
                 {:git/url "https://github.com/cognitect-labs/test-runner"
                  :sha "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}
    :main-opts ["-m" "cognitect.test-runner"
-               "-d" "test"]}}}
+               "-d" "test"]}
+  :cljdoc {:extra-deps {planck {:mvn/version "2.23.0"}}}
+  :cljs-runner
+    {:extra-deps {olical/cljs-test-runner {:mvn/version "3.7.0"},
+		  pjstadig/humane-test-output {:mvn/version "0.10.0"}},
+     :extra-paths ["src" "test" "cljs-test-runner-out/gen"],
+     :main-opts ["-m" "cljs-test-runner.main" "--doo-opts"
+		  "dooopts.edn" "-x" "planck"]}}}

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,6 +1,7 @@
 {:cljdoc.doc/tree [["Readme" {:file "README.md"}]
                    ["Changes" {:file "CHANGELOG.md"}]
                    ["Getting Started" {:file "doc/getting-started.md"}]
+                   ["Getting Started in Clojurescript" {:file "doc/getting-started-cljs.md"}]
                    ["Collections" {:file "doc/collections.md"}]
                    ["Useful Predicates" {:file "doc/useful-predicates.md"}]
                    ["Expecting More" {:file "doc/more.md"}]

--- a/doc/getting-started-cljs.md
+++ b/doc/getting-started-cljs.md
@@ -1,0 +1,197 @@
+# Getting Started with expectations/clojure-test using Clojurescript
+
+You can use `expectations/clojure-test` to run tests in both Clojure
+and Clojurescript.  Many tests will work without changes in both
+Clojure and Clojurescript, though of course some will require
+changes for the different environments.  This section describes how
+to use `expectations/clojure-test` in Clojurescript and the differences
+from using it in Clojure -- see the other sections for details of how
+to use it in Clojure for a complete picture.
+
+
+## Installation
+
+In order to run `expectations/clojure-test` with Clojurescript, you
+will use `olical/cljs-test-runner` and the Clojure tool `clj`.
+
+Your `deps.edn` should include this information:
+
+```clojure
+{:aliases {:cljs-runner
+             {:extra-deps {expectations/cljc-test {:mvn/version "1.4.1"},
+                           olical/cljs-test-runner {:mvn/version "3.7.0"},
+                           pjstadig/humane-test-output {:mvn/version "0.10.0"}},
+              :extra-paths ["src" "test" "cljs-test-runner-out/gen"],
+              :main-opts ["-m" "cljs-test-runner.main" "--doo-opts"
+	                  "dooopts.edn" "-x" "planck"]}}}
+```
+
+You will need two small `.edn` files in your project:
+
+`dooopts.edn`:
+```clojure
+{:paths {:planck "planck --compile-opts planckopts.edn"}}
+```
+
+`planckopts.edn`:
+```clojure
+{:warnings {:private-var-access false}}
+```
+
+To run the tests, you run:
+
+```
+clj -A:cljs-runner
+```
+
+These tests will take a good while longer to run than the same tests
+in Clojure, so if you don't get any output for a while, that is not
+necessarily a bad thing.
+
+### Requirements
+
+The Clojurescript version of `expectations/clojure-test` works (at present)
+only with a specific implementation of self-hosted Clojurescript:
+[`planck`](https://planck-repl.org).  You will have to install `planck`
+yourself in order to use `expectations/clojure-test` with Clojurescript.
+
+You will have to get `planck -h` to work locally.  See
+[here](https://planck-repl.org) for instructions on how to install
+`planck` on a variety of systems.  Planck `2.24.0` or later is required.
+
+### Humane Test Output
+
+The use of Paul Stadig's
+[Humane Test Output](https://github.com/pjstadig/humane-test-output), is
+optional for the Clojure version of `expectations/clojure-test` but it is
+required for the Clojurescript version of `expectations/clojure-test`.
+
+## The Basics
+
+This example is the Clojurescript version of the quick comparison provided
+for the Clojure version of `expectations/clojure-test`, and provides a quick
+comparison with `clojure.test` (the tests match those in the [`clojure.test`
+documentation](http://clojure.github.io/clojure/clojure.test-api.html)):
+
+```clojure
+(require '[expectations.clojure.test :refer [defexpect expect expecting]])
+
+(defexpect simple-test                  ; (deftest simple-test
+  (expect 4 (+ 2 2))                    ;   (is (= 4 (+ 2 2)))
+  (expect number? 256)                     ;   (is (instance? Long 256))
+  (expect (.startsWith "abcde" "ab"))   ;   (is (.startsWith "abcde" "ab"))
+  (expect ##Inf (/ 1 0))                ;   (is (thrown? ArithmeticException (/ 1 0)))
+  (expecting "Arithmetic"               ;   (testing "Arithmetic"
+    (expecting "with positive integers" ;     (testing "with positive integers"
+      (expect 5 (+ 2 2))                ;       (is (= 4 (+ 2 2)))
+      (expect 7 (+ 3 4)))               ;       (is (= 7 (+ 3 4))))
+    (expecting "with negative integers" ;     (testing "with negative integers"
+      (expect -4 (+ -2 -2))             ;       (is (= -4 (+ -2 -2)))
+      (expect -1 (+ 3 -4)))))           ;       (is (= -1 (+ 3 -4))))))
+```
+
+The third example could also be written as follows, since `expect`
+allows an arbitrary predicate in the "expected" position:
+
+```clojure
+  (expect #(.startsWith % "ab") "abcde")
+```
+
+Or like this, since `expect` allows a regular expression in the "expected" position:
+
+```clojure
+  (expect #"^ab" "abcde")
+```
+
+Both of these more accurately reflect an expectation on the actual
+value `"abcde"`, that the string begins with `"ab"`, than the `is`
+equivalent which has the actual value embedded in the test expression.
+Separating the "expectation" (value or predicate) from the "actual"
+expression being tested often makes the test much clearer.
+
+## Differences from the Clojure version of `expectations/clojure-test`
+
+Here is the list of features from Expectations supported by the
+Clojure version of `expectations.clojure.test` where there are
+differences in the Clojurescript implementation.
+
+### * Class test 
+Classes are different in Clojurescript.
+
+Classes are all different in Clojurescript, and in some cases things
+that would be a class in Clojure are different in Clojurescript.  For
+instance, lists are a class:
+```clojure
+(defexpect class-test cljs.core/List '(a b c))
+```
+and this test passes.  Strings, however, don't have an easily
+discoverable type or class, and are better handled with a predicate:
+```clojure
+(defexpect string-class-test string? "abc")
+```
+In general, the classes in Clojurescript will not be the same as
+the classes in Clojure.  You can do this to write a test that
+will work in both environments:
+```clojure
+(defexpect both-class-test (expect (= (type "abc") (type "def"))))
+```
+but you cannot write this:
+```
+(defexpect bad-both-class-test (type "abc") (type "def"))
+```
+because `(type "abc")` yields something that tests positive as a
+`fn?`, causing expectations to think it is a predicate.  Which,
+as it happens, it is not.
+
+### * Exception test 
+
+Exceptions are very different in Clojurescript from Clojure.
+
+The Clojure example:
+```clojure
+(defexpect divide-by-zero ArithmeticException (/ 12 0))
+```
+doesn't even throw an exception -- it returns `##Inf`.
+You can do this for that situation:
+```clojure
+(defexpect divide-by-zero ##Inf (/ 12 0))
+```
+but be careful putting `##Inf` in a reader conditional, as some versions of
+Clojure don't handle that well.  But all of this is a bit off-topic,
+as we are discussing exceptions.
+
+Exceptions certainly exist and can be thrown. You can throw pretty
+much anything in Javascript.  There is no `Throwable` class in
+Clojurecript to distinguish things that can be thrown from anything
+else.  The only exception supported in `expectations/clojure-test`
+in Clojurescript is where the exception is: `js/Error`.  For example:
+```clojure
+(defexpect exception js/Error (count 5))
+```
+will pass, because `(count 5)` throws `js/Error`.
+
+### * `with-test`
+There is no `with-test` in `cljs.test`, so it is not available in
+`expectations/clojure-test`.
+
+### * Specs
+Specs are always supported, and work equivalently to Clojure.
+
+# Useful Additional Information
+
+The end of the Clojure [Getting Started](/doc/getting-started.md) provides
+additional information on how to use `expectations/clojure-test`, and most
+of the information is directly applicable to using `expectations/clojure-test`
+in Clojurescript as well.
+
+# Further Reading
+
+Expectations provides a lot more:
+
+* [Useful Predicates](/doc/useful-predicates.md)
+* [Collections](/doc/collections.md)
+* [Expecting More](/doc/more.md)
+* [Expecting Side Effects](/doc/side-effects.md)
+* [Fixtures & Focused Test Execution](/doc/fixtures-focus.md)
+
+

--- a/dooopts.edn
+++ b/dooopts.edn
@@ -1,0 +1,1 @@
+{:debug false :paths {:planck "planck --compile-opts planckopts.edn"}}

--- a/planckopts.edn
+++ b/planckopts.edn
@@ -1,0 +1,1 @@
+{:warnings {:private-var-access false}}

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>expectations</groupId>
-  <artifactId>clojure-test</artifactId>
-  <version>1.2.1</version>
+  <artifactId>cljc-test</artifactId>
+  <version>1.3.1</version>
   <name>exp-clojure-test</name>
   <description>A clojure.test-compatible version of the classic Expectations testing library.</description>
   <url>https://github.com/clojure-expectations/clojure-test</url>
@@ -29,6 +29,18 @@
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
       <version>1.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>pjstadig</groupId>
+      <artifactId>humane-test-output</artifactId>
+      <version>0.10.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>planck</groupId>
+      <artifactId>planck</artifactId>
+      <version>2.23.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/test/expectations/clojure/test_macros.cljc
+++ b/test/expectations/clojure/test_macros.cljc
@@ -1,0 +1,52 @@
+;; copyright (c) 2019-2020 sean corfield, all rights reserved
+
+(ns expectations.clojure.test-macros
+  "Macros to support testing the testing framework."
+  (:require #?(:clj [clojure.test :refer [is do-report] :as t]
+               :cljs [cljs.test :refer [do-report assert-expr]
+				:refer-macros [is assert-expr] :as t])
+            #?(:cljs [cljs.spec.alpha :as s])
+            #?(:clj [expectations.clojure.test :as sut]
+               :cljs [expectations.clojure.test :include-macros true :as sut])))
+
+(defmacro is-not'
+  "Construct a negative test for an expectation with a symbolic failure."
+  [expectation failure & [msg]]
+  `(let [results# (atom nil)]
+     (with-redefs [do-report (sut/all-report results#)]
+       ~expectation)
+     (t/is (some (fn [fail#]
+                 (= '~failure (:actual fail#)))
+               (:fail @results#)))
+     (when ~msg
+       (t/is (some (fn [fail#]
+                   (re-find ~msg (:message fail#)))
+                 (:fail @results#))))))
+
+(defmacro is-not
+  "Construct a negative test for an expectation with a value-based failure."
+  [expectation failure & [msg]]
+  `(let [results# (atom nil)]
+     (with-redefs [do-report (sut/all-report results#)]
+       ~expectation)
+     (t/is (some (fn [fail#]
+                 (= ~failure (:actual fail#)))
+               (:fail @results#)))
+     (when ~msg
+       (t/is (some (fn [fail#]
+                   (re-find ~msg (:message fail#)))
+                 (:fail @results#))))))
+
+(defmacro passes
+  "Construct a positive test for an expectation with a predicate-based success.
+
+  This is needed for cases where a successful test wraps a failing behavior,
+  such as `thrown?`, i.e., `(expect ExceptionType actual)`"
+  [expectation success]
+  `(let [results# (atom nil)]
+     (with-redefs [do-report (sut/all-report results#)]
+       ~expectation)
+     (t/is (some (fn [pass#]
+                 (~success (:actual pass#)))
+               (:pass @results#)))))
+


### PR DESCRIPTION
Here it is.  I hope I have all of the pieces together -- there are a lot of moving parts in this pull request!  I've done the code and made a pass at documenting it as well, so in addition to this rather long list of things here, the documentation (new file `doc/getting-started-cljs.md` and the end of the `README.md`) might be useful for you.  I've tried really hard to make sure it is all together, but it wouldn't surprise me if I've missed something somewhere.

Notes I made while working on the code:

0. Very impressive use of macros!  I learned a lot just by working on this.  Both the basic expectations ones and the testing ones.  Amazing!

1. I have made all of the source changes by trying to change as few lines as possible, and have hand formatted the things I did change.  The point is to have a diff show the bare minimum set of changes, so you can easily see what I have done.  Given that I am a big proponent of source formatting, this has been a challenge, to be sure.  I also didn't want to intrude on your approach to source formatting (though I expect that I could configure zprint to do it "your way").  But I tried to
minimize changes.  The formatting of what you see is not ideal from my standpoint, but the point is to minimize your effort for review.

2. One can't really do run-time requires in cljs:
``` 
    Calls to `require` must appear at the top-level.   
``` 
So if we are to allow humane-test-output, it has to be there all the time.  I think we should, since every bit of help is worth it.

The alternative would be to do more of the diffing like classic expectations does and output it ourselves.  Which, if you think it would be useful, is something I would consider contributing (as I already have code to handle strings, discussed much later in this list).  If we did that, we could dump HTO in cljs and maybe in clj as well. But for now, the cljs version requires HTO and hacks it to work with the locally created `:diffs`.  See below for details.

The same goes for spec -- no way to really use it only if it is available. So, the cljs version requires spec to be there.  Which isn't a big deal.

3. The doc for humane-test-output for cljs says that it just works without activation.  Not so as I could tell -- you have to at least call `(pjstadig.util/define-fail-report)` to get it to work in cljs.

Here is the code for that, which you may care about for the next item:

```clojure 
(defn define-fail-report [] 
  #?(:clj (defmethod report :fail [& args] 
            (with-test-out 
            (report- (first args)))) 
    :cljs (defmethod cljs.test/report [:cljs.test/default :fail] 
            [event] 
            (report- (p/convert-event event))))) 
``` 

4. The cljs/cljc version of humane-test-output handles :diffs differently than the clj version (i.e., it ignores whatever you pass in), so I had to kind of hack a patch into it as part of activating it.  See the cljs code at "(def humane-test-output?" in test.cljc.  It would be reasonable to get them to change that I suppose.  This change seemed really awful when I first hacked it in, but over time I became more tolerant of it.  I'm not sure why. I suppose because I didn't want to wait for two libraries to change just to get it to work at all.  And because it is so simple as to be transparent, I suppose.

5. I had to use a number of `planck` routines to get this to work, so it is clearly wedded to planck.  I suspect that lumo, the other self-hosted cljs environment, has similar routines and that it could be made to work there as well.  I think the macro situation is so different in regular cljs that I don't have any idea how to make this work, since without a cljs environment around when you expand the macros, none of the resolve (or find-var) stuff is going to work.

6. Exceptions exist and can be thrown in Javascript. You can throw pretty much anything in Javascript.  There is no `Throwable` class in cljs to distinguish things that can be thrown from anything else.  This makes it hard to distinguish a potential Exception from anything else that shows up as "expected" and know when to generate the `(is thrown? ...)` form.

  At present the only exception you can look for (i.e., where `(is thrown? ...)` is used) is js/Error.  That isn't substantially different from what classic expectations does with cljs exceptions, I think.

  I don't know if this is a major limitation or not.  I suspect that I could figure out how to support `:default` as the `expected`, and in that case I would accept anything that was thrown, but not by using `(is thrown? ...)`, rather by doing a `(try (catch :default ...))` which is a special cljs thing to catch anything that was thrown. I can work on this if you want (or we could do that in a later update).

7. I spent way too long dealing with the fact that classes (such as they are in Javascript) and functions both return true to `(fn? ...)`.  Plus, there is no `(class? ...)` in cljs.  This makes distinguishing predicates from classes *really* hard.  I have managed to separate them by looking at the results of printing them, as functions print as `"#object[Function]"`, where classes do not.  I could, instead, have looked at the length of the arglist, as classes have a null arglist and predicates to not.  But however it is done, this distinction is vital.  Awful, I think, but vital.

8. use-fixtures -- this is a macro in cljs.test, and apparently we just really want the cljs.test behavior.  So we pass through directly to the cljs.test macro using our own macro.  The approach for clj using apply doesn't work in cljs.

9. from-clojure-test:  This is a challenge in cljs, where you can't modify metadata on vars.  Planck has a way to do this, and it seems to work for clj as well, so I went with that.  The arglists just don't come over, and I don't know why or if that will become a problem. Doesn't seem to be problem so far.

10. Using the cljs version of humane-test-output with a modern cljs version produces lots of warnings.  HTO doesn't really do anything wrong, it uses what appears to be a legitimate call to a function in `cljs.pprint`, but that call uses private functions which (relatively) recently have started to throw warnings during cljs compilation. These warnings can be disabled, which I have done by passing some options to planck.  Another reason to dump HTO, I suppose, long term.

11.  Getting the clj tests to work for cljs was at least as much work as getting `test.cljc` modified, perhaps more.  The only remaining pain is that the spec testing doesn't work if the `(s/def ...)` is in the same compilation unit as the `(deftest ... (expect ...))` form. To work around this, I stuck it at the end of `test.cljc` for cljs instead of making yet another file in the testing area.  (It also doesn't work if it is in `test_macros.cljc`). Everybody who uses expectations.clojure.test for cljs will therefore get a single `(s/def ...)` spec defined, but since it is namespaced it doesn't seem like a terrible thing.  I expect that another file in the testing area would also solve this if you prefer.  Seems odd to have a file with one line in it, but that would almost certainly work.

12. I changed the artifact-id to be `cljc-test` from `cloure-test"` and learned that the artifact-id isn't really related to the namespace, which was news to me.  Usually they are related so I assumed that was necessary, which it appears it is not.  In our discussion on github, I thought that you implied that changing the artifact-id and not the namespace would be your favored solution to the restrictions in `doo` for self-hosted cljs. I probably would have changed the namespace to follow the artifact-id so that they went together, for no reason other than trying to reduce surprises for users (and because I incorrectly thought it was required). But this works, and seems reasonable now that I've lived with it a while.  I would be a a lot of work to change the namespace everywhere, and disrupt current users as well, so this seems like a good compromise (though the artifact-id change will disrupt current users a bit as well when they upgrade).

13. The end of README.md has instructions for running the cljs tests, as well as how to get a planck cljs REPL working with `expectations/clojure-test` loaded inside if you want to experiment with it.

14. Getting cljdoc to work was, as usual, interesting.  I love cljdoc, but I find it challenging to get it to analyze cljs files without a lot of work.  This time was no exception.  The `planck.core` namespace is built into planck, but ... the cljs analysis phase complains that it needs `planck.core`.  Sigh.  So, I eventually found a `planck.core` that actually seems to work in cljdoc on its own, and supplied that and now cljdoc works.  But we don't really want planck as a dependency for `expectations/clojure-test`, since it is only necessary to get cljdoc to work.  And there is no way to tell cljdoc to use this special thing and not have it be part of the dependencies for the .jar for everyone (near as I can tell, anyway).  After a lot of trial and error, emphasis on the error, it seems like the only approach I can find using `deps.edn` is to edit planck into `pom.xml` with "scope provided".  Having done that, it turns out that HTO needs the same treatment, so they are both edited into `pom.xml` by hand, with "scope provided".  Thus, HTO isn't brought in for clj operations unless you want it, and it must be supplied by the user for cljs operations since I could find no way to have a `.jar` file with different deps for clj and cljs let alone a way to specify this in `deps.edn`.  This means that cljs users have to specify HTO on their own, it doesn't get included as a dependency from the .jar.

This all seems to work, but leaves the `pom.xml` file something that needs to be edited by hand, but that seems like the way of things in the `deps.edn` world in any case, so I suppose it is ok. It is already the case that the artifact-id doesn't show up anywhere except `pom.xml`, which is slightly worrisome.  I'm just not used to hand-editing the `pom.xml`, I suppose.  I think of it as something derived from more user friendly configuration information.

The bottom line is, I have run cljdoc locally and it works with the current documentation.  But don't remove planck or HTO from the pom.xml or it will stop working.  I put `[planck "2.23.0"]` in `deps.edn` under the `:cljdoc` alias, even though there is actually no need for it to be there, but it worried me that having it only in the pom.xml would mean it would just get lost.

15. I have made two other changes to my local version of `expectations/clojure-test` for both clj and cljs  which I find helpful (and almost necessary for my use case).  I have not included them in this pull request, but will add them for your review when (if?) we get the current Clojurescript changes integrated::

  a) I have added the "actual" form (before evaluation) to the msg that comes out when a failure occurs.  This is useful for two reasons:

  1. Clojurescript doesn't yet do file names and line numbers pretty much at all (though that is apparently coming), so that when a test fails, it can be mighty hard to figure out *which* test is failing.  With the "actual" form, a simple text search is easy.

  2. I can cut the "actual" form from the failure report and paste it into a repl and reproduce the failure without even having  to find it in the source for the tests.  This was also possible with the classic expectations, and I missed that capability a *lot*.

  Given that I have 945 tests that run in cljs and 1002 in clj, this is a big win in my environment.

  b) I have a lot of tests that expect a string as output, and it is often very long string which wraps onto many multiple lines. The HTO handling of string diffs is pretty much =/not=, which is a long way from the classic Expectations "matched/diverges" approach to strings, and pretty useless for strings that wrap. 

  So I have implemented the equivalent support to the classic Expectations string handling and stuck that in the msg when the expected and actual are both strings and they don't compare.  This helps me out a lot, and almost certainly wouldn't hurt anyone else.  The code is short and simple and common to both clj and cljs.

That's it for now. 