### PR TITLE
Two small enhancements

### DIFF
--- a/src/expectations/clojure/test.cljc
+++ b/src/expectations/clojure/test.cljc
@@ -126,6 +126,32 @@
                     (catch Throwable _))
           :cljs (boolean (s/get-spec e)))))
 
+(defn str-match
+  "Returns the match off of the beginning of two strings."
+  [a b]
+  (loop [a-seq (seq a)
+         b-seq (seq b)
+         match 0]
+    (if (= (first a-seq) (first b-seq))
+      (recur (next a-seq) (next b-seq) (inc match))
+      (subs a 0 match))))
+
+(defn str-diff
+  "Returns three strings [only-in-a only-in-b in-both]"
+  [a b]
+  (let [match (str-match a b)
+        match-len (count match)]
+    [(subs a match-len) (subs b match-len) match]))
+
+(defn str-msg
+  "Given output from str-diff, produce a message about the difference."
+  [a b in-both]
+  (str "matches: " (pr-str in-both)
+       "\n>>>  expected diverges: " (pr-str
+                                      (clojure.string/replace a in-both ""))
+       "\n>>>    actual diverges: " (pr-str
+                                      (clojure.string/replace b in-both ""))))
+
 ;; smart equality extension to clojure.test assertion -- if the expected form
 ;; is a predicate (function) then the assertion is equivalent to (is (e a))
 ;; rather than (is (= e a)) and we need the type check done at runtime, not
@@ -156,12 +182,19 @@
                        :expected '~form, :actual (if (fn? e#)
                                                    (list '~e a#)
                                                    a#)})
-         (t/do-report {:type :fail, :message (if ~conform?
-                                               (if ~msg
-                                                 (str ~msg "\n"
-                                                      (explain-str?# e# a#))
-                                                 (explain-str?# e# a#))
-                                               ~msg)
+	 (t/do-report
+           (let [[_ _ in-both# :as diff-vec#]
+                   (when (and (string? e#) (string? a#)) (str-diff e# a#))]
+             {:type :fail,
+              :message (if ~conform?
+                         (if ~msg
+                           (str ~msg "\n" (explain-str?# e# a#))
+                           (explain-str?# e# a#))
+                         (if diff-vec#
+			   ; Both e# an a# are strings, put a nice
+			   ; comparison in the msg.
+                           (str ~msg "\n" (str-msg e# a# in-both#) "\n")
+                           ~msg)),
                        :diffs (if humane?#
                                 [[a# (take 2 (data/diff e# a#))]]
                                 [])
@@ -176,7 +209,7 @@
                                      humane?#
                                      [a#]
                                      :else
-                                     (list '~'not (list '~'=? e# a#)))}))
+                                     (list '~'not (list '~'=? e# a#)))})))
        r#)))
 
 (defmacro ^:no-doc ?

--- a/src/expectations/clojure/test.cljc
+++ b/src/expectations/clojure/test.cljc
@@ -183,7 +183,7 @@
                                                    (list '~e a#)
                                                    a#)})
 	 (t/do-report
-           (let [[_ _ in-both# :as diff-vec#]
+           (let [[_# _# in-both# :as diff-vec#]
                    (when (and (string? e#) (string? a#)) (str-diff e# a#))]
              {:type :fail,
               :message (if ~conform?
@@ -279,7 +279,9 @@
                   ~msg
                   (conj ~msg)
                   ~(not= e e')
-                  (conj (str "  within: " ~within))))]
+                  (conj (str "  within: " ~within))
+                  :else 
+		  (conj (str (pr-str '~a) "\n"))))]
      (cond
       (and (sequential? a) (= 'from-each (first a)))
       (let [[_ bindings & body] a]


### PR DESCRIPTION
There are two commits in this PR.

1. The first does a better string compare.  It is functionally equivalent to the classic expectations `strings-difference`, but is implemented differently and is also factored differently so that it fits in with the code in `expectations/clojure-test`.  The other small difference is that it tells you which difference you are looking at in words.

2. The second is where, on failure, the actual form is added as an addendum to the msg.  This doesn't change the expected or actual output, and is just a change to the message -- which I would hope would not upset other code, as someone could have put all of this in the msg themselves.  Which, if you don't like this enhancement, I suppose I could do by defining my own macro which would expand to `expect` with the actual in the msg as well as the actual place.  Anyway, see what you think of this.

3. I have also attached  a file `test.zprint.txt` (since it wouldn't take `test.zprint.cljc`)
[test.zprint.txt](https://github.com/clojure-expectations/clojure-test/files/5093430/test.zprint.txt)
 which is the original `test.cljc` file before my changes after it has been formatted with zprint.   I have never attached a file like this to a PR, so if it doesn't work, I'll find some other way to get it to you.  You will of course want to rename it to have a `.cljc` extension before you deal with it.

The biggest change is that the `cond` forms are recognized and zprint attempts to pair up the `cond` clauses.  zprint isn't primarily an indenter -- it completely reformats based on a width (80 columns in this example, but it does whatever you want).  In its classic mode, which is what you have recieved, it completely ignores the whitespace in the file and just returns the "best" formatting it can based on the width.  It is quite configurable, so that it can be configured to do things whatever way people want it to.  Anyway, just something to see.   I care about this from a debugging standpoint as I find the structure of Lisps to be visually useful for understanding the code.

4. I'll do the additional test file, but it will probably be Thursday or Friday before I can get to it, as I'm away Wednesday.  But I will do it relatively soon.  I wanted to get these small things to you as I had a short window tonight.

Thanks for working with me, this has been more fun than I expected it would be!