### PR TITLE
Pull cljs spec def into test directory, and add some tests for previous enhancements

### DIFF
--- a/src/expectations/clojure/test.cljc
+++ b/src/expectations/clojure/test.cljc
@@ -126,7 +126,7 @@
                  (catch Throwable _))
           :cljs (boolean (s/get-spec e)))))
 
-(defn str-match
+(defn ^:no-doc str-match
   "Returns the match off of the beginning of two strings."
   [a b]
   (loop [a-seq (seq a)
@@ -136,14 +136,14 @@
       (recur (next a-seq) (next b-seq) (inc match))
       (subs a 0 match))))
 
-(defn str-diff
+(defn ^:no-doc str-diff
   "Returns three strings [only-in-a only-in-b in-both]"
   [a b]
   (let [match (str-match a b)
         match-len (count match)]
     [(subs a match-len) (subs b match-len) match]))
 
-(defn str-msg
+(defn ^:no-doc str-msg
   "Given output from str-diff, produce a message about the difference."
   [a b in-both]
   (str "matches: " (pr-str in-both)

--- a/src/expectations/clojure/test.cljc
+++ b/src/expectations/clojure/test.cljc
@@ -551,6 +551,3 @@
 (doseq [f '[#?@(:clj [run-all-tests run-tests test-all-vars test-ns with-test])
             test-var test-vars]]
   (from-clojure-test f))
-
-; For testing expectations itself in cljs
-#?(:cljs (s/def ::small-value (s/and pos-int? #(< % 100))))

--- a/test/expectations/clojure/test_spec.cljs
+++ b/test/expectations/clojure/test_spec.cljs
@@ -1,0 +1,9 @@
+;; copyright (c) 2020 sean corfield, all rights reserved
+
+(ns expectations.clojure.test-spec
+  "Need to define spec in a separate compilation unit from where it is
+  referenced in cljs."
+  (:require [cljs.spec.alpha :as s]))
+
+(s/def ::small-value (s/and pos-int? #(< % 100)))
+

--- a/test/expectations/clojure/test_test.cljc
+++ b/test/expectations/clojure/test_test.cljc
@@ -17,6 +17,7 @@
                       :refer-macros [deftest is testing assert-expr
                                          use-fixtures]])
             #?(:cljs [cljs.spec.alpha :as s])
+	    #?(:cljs [expectations.clojure.test-spec])
             #?(:clj [expectations.clojure.test :refer
                      [from-each in more more-of] :as sut]
                :cljs [expectations.clojure.test
@@ -94,14 +95,12 @@
          (catch Throwable _
            (println "\nOmitting Spec tests for Clojure" (clojure-version)))))
 
-; Note :expectations.clojure.test/small-value is defined at the end of
-; expectations.clojure.test/test.cljc for cljs testing.  Defining it here
-; does not work.
 #?(:cljs (deftest spec-test
-           (is (sut/expect :expectations.clojure.test/small-value (* 13 4)))
-           (is-not' (sut/expect :expectations.clojure.test/small-value
-                                (* 13 40))
-                    (not (=? :expectations.clojure.test/small-value 520)))))
+           (is (sut/expect :expectations.clojure.test-spec/small-value
+                           (* 13 4)))
+           (is-not'
+             (sut/expect :expectations.clojure.test-spec/small-value (* 13 40))
+             (not (=? :expectations.clojure.test-spec/small-value 520)))))
 
 (deftest collection-test
   (is (sut/expect {:foo 1} (in {:foo 1 :cat 4})))

--- a/test/expectations/clojure/test_test.cljc
+++ b/test/expectations/clojure/test_test.cljc
@@ -173,3 +173,25 @@
     (is-not' (control-test-1) (not (zero? 1)))
     (finally
       (reset! control 0))))
+
+; Unit test for string compare routines
+
+(deftest string-test
+  (is (= "abc" (sut/str-match "abcdef" "abcefg")))
+  (is (= ["def" "efg" "abc"] (sut/str-diff "abcdef" "abcefg")))
+  (is (= "matches: \"abc\"\n>>>  expected diverges: \"def\"\n>>>    actual diverges: \"efg\""
+      (sut/str-msg "abcdef" "abcefg" "abc"))))
+
+; Test use of string compare routines as well as actual form in message
+; on failure.  Tests are similar, but cljs one can be run with 
+; humane-test-output while clj one cannot.
+
+#?(:clj (deftest ^:negative string-compare-failure-test
+          (is-not' (sut/expect "abcdef" (str "abc" "efg"))
+                   (not (=? "abcdef" "abcefg"))
+                   #"(?is)(str \"abc\" \"efg\").*matches: \"abc\""))
+   :cljs (deftest string-compare-failure-test
+           (is-not' (sut/expect "abcdef" (str "abc" "efg"))
+                    ["abcefg"]
+                    #"(?is)(str \"abc\" \"efg\").*matches: \"abc\"")))
+


### PR DESCRIPTION
There are three commits in this PR:

1. The first pulls the cljs spec definition into a file in the test directory.  I thought that your comment about doing this implied that you would like it if the cljs and clj spec tests shared as much as possible, which might be only the spec definition.  I tried to do that, but I was unable to find a way to make the clj version share anything with the cljs version.  I'm not sure how in the world you even figured out how to __do__ the clj version -- very clever.  But none of the things I tried to use the spec defined in the new file worked for the clj version.  Ultimately I left it alone, and made the file `.cljs`, and let them be essentially separate.  The clj version is pretty nicely encapsulated anyway -- having tried 5 or 6 ways of splitting it up, I can't say that any of them were any clearer, and probably much less so.  Anyway, the first commit gets the `(s/def..)` out of `test.cljc` anyway.

2. I wasn't sure you were going to take the two enhancements in the previous PR, but since you did, I added some very simple tests for them.  Some simple unit tests for the string compare, and tests for both clj and cljs w/HTO for the actual form in the message and the better string compare in operation.  Nothing fancy, but they do have at least something to say that they work at all.

3. I forgot to ^:no-doc the string compare routines, so I fixed that.
................
A question about possible future work I might jump into:  In the event that I had some free time to explore enhancing `expectations/clojure-test` with better comparisons (with the thought of both moving beyond HTO and getting back something like the nice comparisons on failure from classic Expectations), what is your preference with respect to picking up code from classic Expectations?  I didn't do that with the string compare, since it needed to be factored differently to fit in and it didn't actually work in cljs anyway when I tried it (interestingly enough).  I don't know if it would always have to be refactored to fit into `expectations/clojure-test`, I haven't explored that in depth.  

I do think that there would probably need to be some architecture work to figure out where to integrate a bunch of comparisons, since the way I blended in the fancy string compare made sense as a small change, but it doesn't scale (as the saying goes).  Anyway, I have some things to do in zprint right now so I'm not probably going to jump into looking at this right away (or necessarily ever), but I wanted to see where you were with reusing code from Expectations when and if that makes sense.  I'm kind of assuming that you wouldn't like to do that, which is fine by me, but I don't really know and thought it worth a question.